### PR TITLE
cast maxDepth to unsigned long to avoid error

### DIFF
--- a/JSON/SBJsonStreamParser.m
+++ b/JSON/SBJsonStreamParser.m
@@ -119,7 +119,7 @@
 }
 
 - (void)maxDepthError {
-    self.error = [NSString stringWithFormat:@"Input depth exceeds max depth of %lu", maxDepth];
+    self.error = [NSString stringWithFormat:@"Input depth exceeds max depth of %lu", (unsigned long)maxDepth];
     self.state = [SBJsonStreamParserStateError sharedInstance];
 }
 


### PR DESCRIPTION
This had an issue with the "Values of type NSUInteger should not be used as format argument; add an explicit case to 'unsigned long' instead" error - this will work for 32 bit or 64 bit.